### PR TITLE
bugFix/SignalAddress username string pointer memory size fix

### DIFF
--- a/ios/SignalMessagingSwift/libsignal-protocol-swift-master/libsignal-protocol-swift/Misc/SignalAddress.swift
+++ b/ios/SignalMessagingSwift/libsignal-protocol-swift-master/libsignal-protocol-swift/Misc/SignalAddress.swift
@@ -38,7 +38,7 @@ public final class SignalAddress {
     public init(name: String, deviceId: Int32) {
         self.name = name
         self.deviceId = deviceId
-        let count = name.utf8.count
+        let count = name.utf8.count+1
         self.namePointer = UnsafeMutablePointer<Int8>.allocate(capacity: count)
         namePointer.assign(from: name, count: count)
         self.address = UnsafeMutablePointer<signal_protocol_address>.allocate(capacity: 1)


### PR DESCRIPTION
SignalAddress cString creation extra chars fixed for older iOS versions affecting the iPhone 5.
The issue was in the memory allocation that excluded the null terminator and fetched more characters from memory.
Tested values on both 10.3.1 and 12.1, no regression showed up.