### PR TITLE
added tls/ssl compatibility support to api caller

### DIFF
--- a/android/src/main/java/lt/imas/react_native_signal/signal/SignalServer.java
+++ b/android/src/main/java/lt/imas/react_native_signal/signal/SignalServer.java
@@ -85,7 +85,7 @@ public class SignalServer {
         }
 
         ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.COMPATIBLE_TLS)
-                .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0)
+                .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0, TlsVersion.SSL_3_0)
                 .cipherSuites(
                         CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
                         CipherSuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,


### PR DESCRIPTION
Added support for tls/ssl compatibility support to okhttp api client as described in https://github.com/square/okhttp/wiki/HTTPS.

This covers Sentry issue 772029912.