### PR TITLE
remove sentry lib from sigmal

### DIFF
--- a/ios/SignalMessagingSwift.xcodeproj/project.pbxproj
+++ b/ios/SignalMessagingSwift.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		6979038D21E2831B00484ABB /* legacy_message.m in Sources */ = {isa = PBXBuildFile; fileRef = 6979038921E2831B00484ABB /* legacy_message.m */; };
 		6979038E21E2831B00484ABB /* NSData+OWS.m in Sources */ = {isa = PBXBuildFile; fileRef = 6979038C21E2831B00484ABB /* NSData+OWS.m */; };
 		6979039021E2844400484ABB /* LegacyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6979038F21E2844400484ABB /* LegacyMessage.swift */; };
-		69D45C8A241AB1D60008AEE9 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69D45C89241AB1D60008AEE9 /* Sentry.framework */; };
 		9573BEC820F3D6B700C720C3 /* MessagesStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9573BEBD20F3D6B600C720C3 /* MessagesStorage.swift */; };
 		9573BEC920F3D6B700C720C3 /* SenderKeyStorePillar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9573BEBE20F3D6B600C720C3 /* SenderKeyStorePillar.swift */; };
 		9573BECA20F3D6B700C720C3 /* MessageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9573BEBF20F3D6B600C720C3 /* MessageDTO.swift */; };
@@ -86,19 +85,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		690DC5BA2216A250001EB112 /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		690DC61722173C6E001EB112 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Logger.swift; path = SignalMessagingSwift/Signal/Logger.swift; sourceTree = SOURCE_ROOT; };
 		6979038921E2831B00484ABB /* legacy_message.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = legacy_message.m; path = "SignalMessagingSwift/legacy-support/legacy_message.m"; sourceTree = SOURCE_ROOT; };
 		6979038A21E2831B00484ABB /* NSData+OWS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+OWS.h"; path = "SignalMessagingSwift/legacy-support/NSData+OWS.h"; sourceTree = SOURCE_ROOT; };
 		6979038B21E2831B00484ABB /* legacy_message.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = legacy_message.h; path = "SignalMessagingSwift/legacy-support/legacy_message.h"; sourceTree = SOURCE_ROOT; };
 		6979038C21E2831B00484ABB /* NSData+OWS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+OWS.m"; path = "SignalMessagingSwift/legacy-support/NSData+OWS.m"; sourceTree = SOURCE_ROOT; };
 		6979038F21E2844400484ABB /* LegacyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyMessage.swift; sourceTree = "<group>"; };
-		69CC15B2241AA89800F2D3CE /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		69CC15B4241AA8D300F2D3CE /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		69CC15C3241AA95B00F2D3CE /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		69CC15D1241AAA7800F2D3CE /* libSentry.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libSentry.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		69CC15EA241AAD9500F2D3CE /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		69D45C89241AB1D60008AEE9 /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9573BEBD20F3D6B600C720C3 /* MessagesStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MessagesStorage.swift; path = SignalMessagingSwift/Signal/MessagesStorage.swift; sourceTree = SOURCE_ROOT; };
 		9573BEBE20F3D6B600C720C3 /* SenderKeyStorePillar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SenderKeyStorePillar.swift; path = SignalMessagingSwift/Signal/SenderKeyStorePillar.swift; sourceTree = SOURCE_ROOT; };
 		9573BEBF20F3D6B600C720C3 /* MessageDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MessageDTO.swift; path = SignalMessagingSwift/Signal/MessageDTO.swift; sourceTree = SOURCE_ROOT; };
@@ -122,7 +114,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				69D45C8A241AB1D60008AEE9 /* Sentry.framework in Frameworks */,
 				691307102107F5B900B3C1FD /* SignalProtocol.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -133,13 +124,6 @@
 		6913070A2107F5B900B3C1FD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				69D45C89241AB1D60008AEE9 /* Sentry.framework */,
-				69CC15EA241AAD9500F2D3CE /* Sentry.framework */,
-				69CC15D1241AAA7800F2D3CE /* libSentry.a */,
-				69CC15C3241AA95B00F2D3CE /* Sentry.framework */,
-				69CC15B4241AA8D300F2D3CE /* Sentry.framework */,
-				69CC15B2241AA89800F2D3CE /* Sentry.framework */,
-				690DC5BA2216A250001EB112 /* Sentry.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/ios/SignalMessagingSwift/Signal/Logger.swift
+++ b/ios/SignalMessagingSwift/Signal/Logger.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import Sentry
 
 
 class Logger: NSObject {
@@ -20,25 +19,29 @@ class Logger: NSObject {
     }
     
     func sendInfoMessage(message: String) {
-        if (!isLoggable) { return }
-        let event = Event(level: .info)
-        event.message = message
-        sendEvent(event: event)
+//        if (!isLoggable) { return }
+//        let event = Event(level: .info)
+//        event.message = message
+//        sendEvent(event: event)
     }
     
     func sendErrorMessage(message: String) {
-        if (!isLoggable) { return }
-        Client.shared?.snapshotStacktrace {
-            let event = Event(level: .error)
-            event.message = message
-            Client.shared?.appendStacktrace(to: event)
-            self.sendEvent(event: event)
-        }
+//        if (!isLoggable) { return }
+//        Client.shared?.snapshotStacktrace {
+//            let event = Event(level: .error)
+//            event.message = message
+//            Client.shared?.appendStacktrace(to: event)
+//            self.sendEvent(event: event)
+//        }
     }
     
-    func sendEvent(event: Event) {
-        if (!isLoggable) { return }
-        Client.shared?.send(event: event)
+    func sendEvent() {
+        //
     }
+    
+//    func sendEvent(event: Event) {
+//        if (!isLoggable) { return }
+//        Client.shared?.send(event: event)
+//    }
     
 }

--- a/ios/SignalMessagingSwift/Signal/RNSignalClientModule.swift
+++ b/ios/SignalMessagingSwift/Signal/RNSignalClientModule.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 import SignalProtocol
-import Sentry
 
 let ERR_WRONG_CONFIG = "ERR_WRONG_CONFIG"
 let ERR_SERVER_FAILED = "ERR_SERVER_FAILED"
@@ -51,15 +50,15 @@ class RNSignalClientModule: NSObject {
         // ---
 
         self.signalClient = SignalClient(username: username, accessToken: accessToken, host: host, logger: logger, signalResetVersion: signalResetVersion)
-        if isLoggable {
-            do {
-                let sentryDSN = config.object(forKey: "errorTrackingDSN") as! String
-                Client.shared = try Client(dsn: sentryDSN)
-                try Client.shared?.startCrashHandler()
-            } catch {
-                // sentry unavailable
-            }
-        }
+//        if isLoggable {
+//            do {
+//                let sentryDSN = config.object(forKey: "errorTrackingDSN") as! String
+//                Client.shared = try Client(dsn: sentryDSN)
+//                try Client.shared?.startCrashHandler()
+//            } catch {
+//                // sentry unavailable
+//            }
+//        }
 
         if !performSoftReset && ProtocolStorage().getLocalUsername() == username && ProtocolStorage().isLocalRegistered() {
             self.signalClient.checkPreKeys()

--- a/ios/SignalMessagingSwift/Signal/SignalClient.swift
+++ b/ios/SignalMessagingSwift/Signal/SignalClient.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 import SignalProtocol
-import Sentry
 
 class SignalClient: NSObject {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-signal-protocol-messaging",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "React Native module for Signal Protocol messaging",
   "main": "index.js"
 }


### PR DESCRIPTION
Per title. Reason: we're not using it anymore and currently it blocks us from updating Sentry to latest version. Commenting out the code to keep it later.